### PR TITLE
Push through proxy authentication

### DIFF
--- a/classes/facebook.php
+++ b/classes/facebook.php
@@ -548,6 +548,20 @@ class Facebook
     }
 
     curl_setopt_array($ch, $opts);
+
+      $ini = eZINI::instance();
+      $proxy = $ini->variable( 'ProxySettings', 'ProxyServer' );
+      if ( $proxy )
+      {
+          curl_setopt( $ch, CURLOPT_PROXY, $proxy );
+          $userName = $ini->variable( 'ProxySettings', 'User' );
+          $password = $ini->variable( 'ProxySettings', 'Password' );
+          if ( $userName )
+          {
+              curl_setopt( $ch, CURLOPT_PROXYUSERPWD, "$userName:$password" );
+          }
+      }
+
     $result = curl_exec($ch);
     if ($result === false) {
       $e = new FacebookApiException(array(

--- a/classes/ngpush_base.php
+++ b/classes/ngpush_base.php
@@ -27,6 +27,7 @@ class ngPushBase
 		$fileHandler->storeContents( $Token );
 
 		$storedToken = $fileHandler->fetchContents();
+
 		if ( $storedToken !== false )
 			return true;
 
@@ -72,6 +73,19 @@ class ngPushBase
 
 			$new_url = $url['scheme'] . '://' . $url['host'] . $url['path'] . ($url['query'] ? '?' . $url['query'] : '');
 			curl_setopt($ch, CURLOPT_URL, $new_url);
+
+            $ini = eZINI::instance();
+            $proxy = $ini->variable( 'ProxySettings', 'ProxyServer' );
+            if ( $proxy )
+            {
+                curl_setopt( $ch, CURLOPT_PROXY, $proxy );
+                $userName = $ini->variable( 'ProxySettings', 'User' );
+                $password = $ini->variable( 'ProxySettings', 'Password' );
+                if ( $userName )
+                {
+                    curl_setopt( $ch, CURLOPT_PROXYUSERPWD, "$userName:$password" );
+                }
+            }
 
 			return self::curl_redir_exec($ch, $data2);
 		}

--- a/classes/ngpush_facebook_base.php
+++ b/classes/ngpush_facebook_base.php
@@ -32,6 +32,20 @@ class ngPushFacebookBase extends ngPushBase
 		$ch = curl_init($url);
 		curl_setopt_array($ch, $options);
 
+
+        $ini = eZINI::instance();
+        $proxy = $ini->variable( 'ProxySettings', 'ProxyServer' );
+        if ( $proxy )
+        {
+            curl_setopt( $ch, CURLOPT_PROXY, $proxy );
+            $userName = $ini->variable( 'ProxySettings', 'User' );
+            $password = $ini->variable( 'ProxySettings', 'Password' );
+            if ( $userName )
+            {
+                curl_setopt( $ch, CURLOPT_PROXYUSERPWD, "$userName:$password" );
+            }
+        }
+
 		$content	= curl_exec($ch);
 		$errno		= curl_errno($ch);
 		$errmsg		= curl_error($ch);

--- a/classes/ngpush_facebook_feed.php
+++ b/classes/ngpush_facebook_feed.php
@@ -39,6 +39,19 @@ class ngPushFacebookFeed extends ngPushFacebookBase
             $ch = curl_init($url);
             curl_setopt_array($ch, $options);
 
+            $ini = eZINI::instance();
+            $proxy = $ini->variable( 'ProxySettings', 'ProxyServer' );
+            if ( $proxy )
+            {
+                curl_setopt( $ch, CURLOPT_PROXY, $proxy );
+                $userName = $ini->variable( 'ProxySettings', 'User' );
+                $password = $ini->variable( 'ProxySettings', 'Password' );
+                if ( $userName )
+                {
+                    curl_setopt( $ch, CURLOPT_PROXYUSERPWD, "$userName:$password" );
+                }
+            }
+
             $content    = curl_exec($ch);
             $errno      = curl_errno($ch);
             $errmsg     = curl_error($ch);

--- a/classes/twitteroauth.php
+++ b/classes/twitteroauth.php
@@ -203,6 +203,19 @@ class TwitterOAuth {
     curl_setopt($ci, CURLOPT_HEADERFUNCTION, array($this, 'getHeader'));
     curl_setopt($ci, CURLOPT_HEADER, FALSE);
 
+    $ini = eZINI::instance();
+    $proxy = $ini->variable( 'ProxySettings', 'ProxyServer' );
+    if ( $proxy )
+    {
+      curl_setopt( $ci, CURLOPT_PROXY, $proxy );
+      $userName = $ini->variable( 'ProxySettings', 'User' );
+      $password = $ini->variable( 'ProxySettings', 'Password' );
+      if ( $userName )
+      {
+          curl_setopt( $ci, CURLOPT_PROXYUSERPWD, "$userName:$password" );
+      }
+    }
+
     switch ($method) {
       case 'POST':
         curl_setopt($ci, CURLOPT_POST, TRUE);


### PR DESCRIPTION
This fix makes ngpush work when a proxy is in place. all the curl and file_get_contents calls have been changed to do that.

Proxy settings need to be added to site.ini file, as follows:

[ProxySettings]
ProxyServer=http://[PROXY_IP_ADDRESS]:[PROXY_PORT]
User=[PROXY_USER]
Password=[PROXY_USERPWD]

